### PR TITLE
Do not accept private keys longer than 32 bytes

### DIFF
--- a/bitcoin.sh
+++ b/bitcoin.sh
@@ -92,7 +92,7 @@ newBitcoinKey() {
 	fi
     elif [[ "$1" =~ ^[0-9]+$ ]]
     then $FUNCNAME "0x$(dc -e "16o$1p")"
-    elif [[ "${1^^}" =~ ^0X([0-9A-F]+)$ ]]
+    elif [[ "${1^^}" =~ ^0X([0-9A-F]{1,64})$ ]]
     then 
 	local exponent="${BASH_REMATCH[1]}"
 	local uncompressed_wif="$(hexToAddress "$exponent" 80 64)"


### PR DESCRIPTION
If the user enters a key in hexadecimal format, it is possible that
they will accidentally type more than 32 bytes. If this happens, the
script will continue normally, but will produce invalid (and
unspendable) WIF keys and addresses.

Therefore, do not accept hexadecimal input longer than 32 bytes.
Shorter inputs are not a problem, since the private key will just
have 0's for the missing digits.
