### PR TITLE
Do not generate invalid bitcoin addresses

### DIFF
--- a/bitcoin.sh
+++ b/bitcoin.sh
@@ -46,6 +46,7 @@ decodeBase58() {
     while read n; do echo -n ${n/\\/}; done
 }
 encodeBase58() {
+    echo -n "$1" | sed -e's/^\(\(00\)*\).*/\1/' -e's/00/1/g'
     dc -e "16i ${1^^} [3A ~r d0<x]dsxx +f" |
     while read -r n; do echo -n "${base58[n]}"; done
 }
@@ -73,14 +74,9 @@ hash160() {
 }
 
 hexToAddress() {
-    local version=${2:-00} x="$(printf "%${3:-40}s" $1 | sed 's/ /0/g')"
-    printf "%34s\n" "$(encodeBase58 "$version$x$(checksum "$version$x")")" |
-    {
-	if ((version == 0))
-	then sed -r 's/ +/1/'
-	else cat
-	fi
-    }
+    local x="$(printf "%2s%${3:-40}s" ${2:-00} $1 | sed 's/ /0/g')"
+    encodeBase58 "$x$(checksum "$x")"
+    echo
 }
 
 newBitcoinKey() {


### PR DESCRIPTION
Some private keys, such as 5JjXbt9zW9ZCLkn2bEjxzkQzpUr4XCQ38HjvjHkPuM1hCdNr4aS,
produce public address hashes with a lot of leading 0 bytes.
These bytes need to be encoded as 1's, which wasn't happening correctly.

In addition, correctly handle the case where somebody specifies a version
byte as a single digit. Before, a call like `hexToAddress $x 0` would
produce a different output from `hexToAddress $x 00`.
