### PR TITLE
Support QTUM, TRX (Tron), and Ethereum-like addresses

### DIFF
--- a/bitcoin.sh
+++ b/bitcoin.sh
@@ -158,6 +158,7 @@ newBitcoinKey() {
             fi
             uncompressed_addr="$(hexToAddress "$(pack "04$X$Y" | hash160)")"
             compressed_addr="$(hexToAddress "$(pack "$y_parity$X" | hash160)")"
+            multisig_1_of_1_addr="$(hexToAddress "$(pack "514104${X}${Y}51AE" | hash160)" 05)"
             qtum_compressed_addr="$(hexToAddress "$(pack "$y_parity$X" | hash160)" 3a)"
             ethereum_addr="$(pack "$X$Y" | sha3-256 | unpack | tail -c 40)"
             tron_addr="$(hexToAddress "$ethereum_addr" 41)"
@@ -173,6 +174,7 @@ newBitcoinKey() {
             echo "uncompressed:"
             echo "    WIF:                  $uncompressed_wif"
             echo "    Bitcoin address:      $uncompressed_addr"
+            echo "    Bitcoin (1-of-1):     $multisig_1_of_1_addr"
             echo "    Ethereum address:     0x$(toEthereumAddressWithChecksum $ethereum_addr)"
             echo "    Tron address:         $tron_addr"
         }

--- a/bitcoin.sh
+++ b/bitcoin.sh
@@ -96,7 +96,7 @@ toEthereumAddressWithChecksum() {
     for i in {0..39}; do
         c=${addrLower:i:1}
         x=${addrHash:i:1}
-        [[ $c =~ [a-f] ]] && [[ $x =~ [9a-f] ]] && c=${c^^}
+        [[ $c =~ [a-f] ]] && [[ $x =~ [89a-f] ]] && c=${c^^}
         addrChecksum+=$c
     done
     echo -n $addrChecksum
@@ -120,10 +120,10 @@ hash160() {
 sha3-256() {
     python3 -c "
 import sys
-import sha3
+from Crypto.Hash import keccak
 data = sys.stdin.buffer.read()
-hash = sha3.keccak_256(data).digest()
-sys.stdout.buffer.write(hash)
+hash = keccak.new(digest_bits=256).update(data)
+sys.stdout.buffer.write(hash.digest())
 "
 }
 

--- a/bitcoin.sh
+++ b/bitcoin.sh
@@ -158,7 +158,8 @@ newBitcoinKey() {
             fi
             uncompressed_addr="$(hexToAddress "$(pack "04$X$Y" | hash160)")"
             compressed_addr="$(hexToAddress "$(pack "$y_parity$X" | hash160)")"
-            multisig_1_of_1_addr="$(hexToAddress "$(pack "514104${X}${Y}51AE" | hash160)" 05)"
+            uncompressed_multisig_1_of_1_addr="$(hexToAddress "$(pack "514104${X}${Y}51AE" | hash160)" 05)"
+            compressed_multisig_1_of_1_addr="$(hexToAddress "$(pack "5121${y_parity}${X}51AE" | hash160)" 05)"
             qtum_compressed_addr="$(hexToAddress "$(pack "$y_parity$X" | hash160)" 3a)"
             ethereum_addr="$(pack "$X$Y" | sha3-256 | unpack | tail -c 40)"
             tron_addr="$(hexToAddress "$ethereum_addr" 41)"
@@ -170,11 +171,12 @@ newBitcoinKey() {
             echo "compressed:"
             echo "    WIF:                  $compressed_wif"
             echo "    Bitcoin address:      $compressed_addr"
+            echo "    Bitcoin (1-of-1):     $compressed_multisig_1_of_1_addr"
             echo "    Qtum address:         $qtum_compressed_addr"
             echo "uncompressed:"
             echo "    WIF:                  $uncompressed_wif"
             echo "    Bitcoin address:      $uncompressed_addr"
-            echo "    Bitcoin (1-of-1):     $multisig_1_of_1_addr"
+            echo "    Bitcoin (1-of-1):     $uncompressed_multisig_1_of_1_addr"
             echo "    Ethereum address:     0x$(toEthereumAddressWithChecksum $ethereum_addr)"
             echo "    Tron address:         $tron_addr"
         }


### PR DESCRIPTION
  * used python3 and sha3 (python lib) to evaluate Ethereum address
    (openssl does not support sha3 (keccak) hash algorithm)
  * removed restriction in 64 chars length for raw private key (exponent)
    (TronWatch wallet ignores BIP32 and BIP44 and uses generated seed
     in 64 bytes length from mnemonic (BIP39) as a long exponent)