### PR TITLE
Fix regex match in newBitcoinKey by changing output of decodeBase58 to uppercase hexadecimal

### DIFF
--- a/bitcoin.sh
+++ b/bitcoin.sh
@@ -73,7 +73,7 @@ decodeBase58() {
     echo "[256 ~r d0<x]dsxx +f"
   } | dc |
   while read n
-  do printf "%02x" "$n"
+  do printf "%02X" "$n"
   done
 }
 


### PR DESCRIPTION
Before change:
```
$ decodeBase58 5JtBDT4uYEX1Ube5FvW3nDgVTsyhcLjvZLCwNnZBptwPRYhf2h4
808c87844bd0fe2db78615fdee25ebfe998502b51eb81ab3a7212eaecb7124b7c1e0754e07
$ newBitcoinKey 5JtBDT4uYEX1Ube5FvW3nDgVTsyhcLjvZLCwNnZBptwPRYhf2h4
```
After change:
```
$ decodeBase58 5JtBDT4uYEX1Ube5FvW3nDgVTsyhcLjvZLCwNnZBptwPRYhf2h4
808C87844BD0FE2DB78615FDEE25EBFE998502B51EB81AB3A7212EAECB7124B7C1E0754E07
$ newBitcoinKey 5JtBDT4uYEX1Ube5FvW3nDgVTsyhcLjvZLCwNnZBptwPRYhf2h4
...
            compressed addresses:
                WIF:                  L1vt5x4EtrfT6otdns9DGayJde1GEz8TPhmh1A54nQF3xujaH3Qt
                Bitcoin (P2PKH):      15QFvsey3CmBZBq4D3FK5EGVxCdcnbWRxS
...
```
Function decodeBase58 is also being used in checkBitcoinAddress but it seems that this change is not breaking anything there.